### PR TITLE
chore: add local development files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Binaries
 bin/
+tmkb
 *.exe
 *.exe~
 *.dll
@@ -23,6 +24,7 @@ vendor/
 # IDE
 .idea/
 .vscode/
+.claude/
 *.swp
 *.swo
 *~
@@ -56,3 +58,4 @@ flask_session/
 # Project-specific exclusions
 tmkb-mvp-tasks.md
 docs/security-settings-review.md
+.mcp.json


### PR DESCRIPTION
## Summary

Adds local development files to `.gitignore` to prevent accidental commits:
- `tmkb`: compiled binary executable
- `.claude/`: Claude Code local configuration directory
- `.mcp.json`: local MCP server config with machine-specific paths

## Rationale

These files are useful for local development but contain machine-specific paths or build artifacts that should not be version controlled.

## Changes

- Added `tmkb` to Binaries section
- Added `.claude/` to IDE section
- Added `.mcp.json` to Project-specific exclusions

🤖 Generated with [Claude Code](https://claude.com/claude-code)