### PR TITLE
fix: bump Go to 1.25.8 for stdlib security fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,14 +97,13 @@ jobs:
 
     - name: Run Trivy vulnerability scanner
       if: always()
-      uses: aquasecurity/trivy-action@e368e328979b113139d6f9068e03accaed98a518 # 0.34.1
+      uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
       with:
         scan-type: 'fs'
         scan-ref: '.'
         format: 'sarif'
         output: 'trivy-results.sarif'
         severity: 'CRITICAL,HIGH'
-        trivy-version: 'v0.69.3'
 
     - name: Upload Trivy results to GitHub Security
       uses: github/codeql-action/upload-sarif@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,6 +104,7 @@ jobs:
         format: 'sarif'
         output: 'trivy-results.sarif'
         severity: 'CRITICAL,HIGH'
+        trivy-version: 'v0.69.3'
 
     - name: Upload Trivy results to GitHub Security
       uses: github/codeql-action/upload-sarif@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v6
       with:
-        go-version: '1.25.7'
+        go-version: '1.25.8'
         cache: true
 
     - name: Download dependencies
@@ -52,7 +52,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v6
       with:
-        go-version: '1.25.7'
+        go-version: '1.25.8'
         cache: true
 
     - name: Run golangci-lint
@@ -76,7 +76,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v6
       with:
-        go-version: '1.25.7'
+        go-version: '1.25.8'
         cache: true
 
     - name: Run gosec
@@ -121,7 +121,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v6
       with:
-        go-version: '1.25.7'
+        go-version: '1.25.8'
         cache: true
 
     - name: Build CLI

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,7 @@ jobs:
         govulncheck ./...
 
     - name: Run Trivy vulnerability scanner
+      if: always()
       uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8 # 0.33.1
       with:
         scan-type: 'fs'


### PR DESCRIPTION
## Summary
- Bumps Go toolchain from 1.25.7 to 1.25.8 across all CI jobs
- Fixes **GO-2026-4602** (`os` — FileInfo can escape from a Root)
- Fixes **GO-2026-4601** (`net/url` — incorrect IPv6 host literal parsing)

These vulnerabilities were flagged by `govulncheck` in CI, reached via `tiktoken-go` in `internal/knowledge/tokens.go`.

## Test plan
- [ ] CI `govulncheck` step passes without errors
- [ ] All other CI jobs unaffected by toolchain bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)