### PR TITLE
ci: remove Trivy scanner from CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,21 +98,6 @@ jobs:
         go install golang.org/x/vuln/cmd/govulncheck@latest
         govulncheck ./...
 
-    - name: Run Trivy vulnerability scanner
-      if: always()
-      uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
-      with:
-        scan-type: 'fs'
-        scan-ref: '.'
-        format: 'sarif'
-        output: 'trivy-results.sarif'
-        severity: 'CRITICAL,HIGH'
-
-    - name: Upload Trivy results to GitHub Security
-      uses: github/codeql-action/upload-sarif@v4
-      with:
-        sarif_file: trivy-results.sarif
-      if: always()
 
   validate:
     name: Validate Patterns


### PR DESCRIPTION
## Summary
- Removes `aquasecurity/trivy-action` and its SARIF upload step from the Security Checks job
- Trivy is redundant — the pipeline already has govulncheck, gosec, CodeQL, and dependency review covering the same ground
- Eliminates future exposure to Trivy supply chain risks (ref: GHSA-69fq-xp46-6x23)

## Test plan
- [ ] CI Security Checks job passes without the Trivy step
- [ ] No regression in other security scanning steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)