### PR TITLE
ci: bump Go from 1.25.8 to 1.25.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v6
       with:
-        go-version: '1.25.9'
+        go-version: '1.25'
         cache: true
 
     - name: Download dependencies
@@ -52,7 +52,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v6
       with:
-        go-version: '1.25.9'
+        go-version: '1.25'
         cache: true
 
     - name: Run golangci-lint
@@ -76,7 +76,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v6
       with:
-        go-version: '1.25.9'
+        go-version: '1.25'
         cache: true
 
     - name: Run gosec
@@ -122,7 +122,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v6
       with:
-        go-version: '1.25.9'
+        go-version: '1.25'
         cache: true
 
     - name: Build CLI

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
       uses: actions/setup-go@v6
       with:
         go-version: '1.25'
+        check-latest: true
         cache: true
 
     - name: Download dependencies
@@ -53,6 +54,7 @@ jobs:
       uses: actions/setup-go@v6
       with:
         go-version: '1.25'
+        check-latest: true
         cache: true
 
     - name: Run golangci-lint
@@ -77,6 +79,7 @@ jobs:
       uses: actions/setup-go@v6
       with:
         go-version: '1.25'
+        check-latest: true
         cache: true
 
     - name: Run gosec
@@ -123,6 +126,7 @@ jobs:
       uses: actions/setup-go@v6
       with:
         go-version: '1.25'
+        check-latest: true
         cache: true
 
     - name: Build CLI

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v6
       with:
-        go-version: '1.25.8'
+        go-version: '1.25.9'
         cache: true
 
     - name: Download dependencies
@@ -52,7 +52,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v6
       with:
-        go-version: '1.25.8'
+        go-version: '1.25.9'
         cache: true
 
     - name: Run golangci-lint
@@ -76,7 +76,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v6
       with:
-        go-version: '1.25.8'
+        go-version: '1.25.9'
         cache: true
 
     - name: Run gosec
@@ -122,7 +122,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v6
       with:
-        go-version: '1.25.8'
+        go-version: '1.25.9'
         cache: true
 
     - name: Build CLI


### PR DESCRIPTION
## Summary
- Bumps `go-version` from `1.25.8` to `1.25.9` in all four `setup-go` steps in `.github/workflows/ci.yml`
- Resolves three govulncheck findings against stdlib that have been failing the Security Checks job on Dependabot PRs (#63, #64):
  - [GO-2026-4947](https://pkg.go.dev/vuln/GO-2026-4947) — `crypto/x509` unexpected work during chain building
  - [GO-2026-4946](https://pkg.go.dev/vuln/GO-2026-4946) — `crypto/x509` inefficient policy validation
  - [GO-2026-4870](https://pkg.go.dev/vuln/GO-2026-4870) — `crypto/tls` TLS 1.3 KeyUpdate DoS

All three fixes shipped in go1.25.9.

## Test plan
- [ ] CI Security Checks job passes (govulncheck clean)
- [ ] Build, Lint, Validate Patterns jobs still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)