### PR TITLE
fix(mcp): negotiate protocol version and honor TMKB_PATTERNS (fixes -32000 reconnect)

### DIFF
--- a/docs/mcp-integration.md
+++ b/docs/mcp-integration.md
@@ -134,7 +134,7 @@ TMKB returns:
 
 **Verify manually**:
 ```bash
-echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}' | /path/to/tmkb serve
+echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}' | /path/to/tmkb serve
 ```
 
 Should return initialize response.
@@ -181,7 +181,7 @@ Should return initialize response.
 
 ### MCP Protocol
 
-- **Protocol Version**: 2025-11-25
+- **Protocol Version**: negotiated — the client's requested version is echoed when supported (`2025-06-18`, `2025-03-26`, `2024-11-05`); otherwise the server falls back to `2025-06-18`
 - **Transport**: stdio (JSON-RPC 2.0 over stdin/stdout)
 - **Capabilities**: Tools only (no resources, prompts, or sampling)
 
@@ -257,6 +257,6 @@ ln -s /other/patterns/* /main/patterns/
 
 ## References
 
-- [MCP Specification](https://modelcontextprotocol.io/specification/2025-11-25)
+- [MCP Specification](https://modelcontextprotocol.io/specification/2025-06-18)
 - [Claude Code MCP Documentation](https://docs.anthropic.com/claude/docs/model-context-protocol)
 - [TMKB GitHub](https://github.com/mark-chris/tmkb)

--- a/examples/claude-code-integration/README.md
+++ b/examples/claude-code-integration/README.md
@@ -143,7 +143,7 @@ The key difference: without TMKB, Claude Code generates code that is functionall
 **"Server failed to start"**
 - Verify the path is absolute: `realpath bin/tmkb`
 - Check the binary is executable: `chmod +x bin/tmkb`
-- Test manually: `echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{}}}' | ./bin/tmkb serve`
+- Test manually: `echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{}}}' | ./bin/tmkb serve`
 
 **Tool not appearing in Claude Code**
 - Restart Claude Code completely (quit and reopen)

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -92,6 +92,16 @@ func init() {
 
 // findPatternsDir locates the patterns directory
 func findPatternsDir() string {
+	// An explicit TMKB_PATTERNS env var is authoritative: it is how MCP clients
+	// (see .mcp.json) point the stdio server at its patterns, since the server's
+	// working directory is the client's project, not the tmkb repo. Return it
+	// directly rather than falling through to the cwd-relative scan below, so a
+	// misconfigured path surfaces as a clear "failed to load patterns" error
+	// instead of silently falling back to cwd.
+	if env := os.Getenv("TMKB_PATTERNS"); env != "" {
+		return filepath.Clean(env)
+	}
+
 	// Check common locations
 	candidates := []string{
 		"patterns",

--- a/internal/knowledge/integration_test.go
+++ b/internal/knowledge/integration_test.go
@@ -2,7 +2,6 @@ package knowledge
 
 import (
 	"os"
-	"path/filepath"
 	"testing"
 )
 
@@ -274,10 +273,10 @@ func loadPatternsFromDir(t *testing.T) []ThreatPattern {
 // findPatternsDir locates the patterns directory relative to the test
 func findPatternsDir() string {
 	candidates := []string{
-		"../../patterns", // From internal/knowledge
-		"./patterns",     // From repo root
-		"../patterns",    // Alternative
-		filepath.Join(os.Getenv("TMKB_PATTERNS_DIR")), // Environment override
+		"../../patterns",           // From internal/knowledge
+		"./patterns",               // From repo root
+		"../patterns",              // Alternative
+		os.Getenv("TMKB_PATTERNS"), // Environment override (matches the var honored by the CLI)
 	}
 
 	for _, dir := range candidates {

--- a/internal/mcp/handlers_test.go
+++ b/internal/mcp/handlers_test.go
@@ -15,7 +15,7 @@ func TestHandleMessage_Initialize(t *testing.T) {
 		JSONRPC: "2.0",
 		ID:      1,
 		Method:  "initialize",
-		Params:  json.RawMessage(`{"protocolVersion":"2025-11-25","capabilities":{}}`),
+		Params:  json.RawMessage(`{"protocolVersion":"2025-06-18","capabilities":{}}`),
 	}
 	reqData, _ := json.Marshal(req)
 

--- a/internal/mcp/initialize.go
+++ b/internal/mcp/initialize.go
@@ -12,6 +12,29 @@ type initializeParams struct {
 	ClientInfo      map[string]interface{} `json:"clientInfo,omitempty"`
 }
 
+// supportedProtocolVersions lists the MCP protocol revisions this server can
+// speak. The server echoes the client's requested version when it appears
+// here; otherwise it falls back to defaultProtocolVersion.
+var supportedProtocolVersions = map[string]bool{
+	"2025-06-18": true,
+	"2025-03-26": true,
+	"2024-11-05": true,
+}
+
+// defaultProtocolVersion is returned when the client requests a version this
+// server does not support. It must be a revision real MCP clients accept, so a
+// standards-compliant client can still complete the handshake.
+const defaultProtocolVersion = "2025-06-18"
+
+// negotiateProtocolVersion implements MCP version negotiation: echo the
+// client's requested version when supported, otherwise return our default.
+func negotiateProtocolVersion(requested string) string {
+	if supportedProtocolVersions[requested] {
+		return requested
+	}
+	return defaultProtocolVersion
+}
+
 // handleInitialize handles the initialize request
 func handleInitialize(s *Server, params json.RawMessage) (interface{}, error) {
 	// Check if already initialized
@@ -26,13 +49,9 @@ func handleInitialize(s *Server, params json.RawMessage) (interface{}, error) {
 		return nil, fmt.Errorf("invalid initialize params: %w", err)
 	}
 
-	// Version negotiation: support 2025-11-25 only
-	protocolVersion := "2025-11-25"
-	if p.ProtocolVersion != protocolVersion {
-		// Client requested unsupported version, respond with our version
-		// Client may disconnect if incompatible
-		protocolVersion = "2025-11-25"
-	}
+	// Negotiate the protocol version: echo the client's requested version when
+	// supported, otherwise fall back to our default.
+	protocolVersion := negotiateProtocolVersion(p.ProtocolVersion)
 
 	// Store protocol version and client capabilities
 	s.mu.Lock()

--- a/internal/mcp/initialize_test.go
+++ b/internal/mcp/initialize_test.go
@@ -12,7 +12,7 @@ func TestHandleInitialize_Success(t *testing.T) {
 	srv := NewServer(idx)
 
 	params := map[string]interface{}{
-		"protocolVersion": "2025-11-25",
+		"protocolVersion": "2025-06-18",
 		"capabilities":    map[string]interface{}{},
 		"clientInfo": map[string]interface{}{
 			"name":    "TestClient",
@@ -27,12 +27,58 @@ func TestHandleInitialize_Success(t *testing.T) {
 	}
 
 	resultMap := result.(map[string]interface{})
-	if resultMap["protocolVersion"] != "2025-11-25" {
-		t.Errorf("expected protocol version 2025-11-25, got %v", resultMap["protocolVersion"])
+	if resultMap["protocolVersion"] != "2025-06-18" {
+		t.Errorf("expected protocol version 2025-06-18, got %v", resultMap["protocolVersion"])
 	}
 
 	if srv.getState() != stateInitializing {
 		t.Errorf("expected state Initializing, got %v", srv.getState())
+	}
+}
+
+func TestHandleInitialize_EchoesSupportedVersion(t *testing.T) {
+	// A supported version other than the default must be echoed back verbatim.
+	idx := knowledge.NewIndex()
+	srv := NewServer(idx)
+
+	params := map[string]interface{}{
+		"protocolVersion": "2025-03-26",
+		"capabilities":    map[string]interface{}{},
+	}
+	paramsJSON, _ := json.Marshal(params)
+
+	result, err := handleInitialize(srv, paramsJSON)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	resultMap := result.(map[string]interface{})
+	if resultMap["protocolVersion"] != "2025-03-26" {
+		t.Errorf("expected echoed version 2025-03-26, got %v", resultMap["protocolVersion"])
+	}
+}
+
+func TestHandleInitialize_FallsBackOnUnsupportedVersion(t *testing.T) {
+	// An unsupported version must fall back to the default so a compliant
+	// client can still complete the handshake (regression test for the
+	// hardcoded 2025-11-25 reply that broke MCP negotiation).
+	idx := knowledge.NewIndex()
+	srv := NewServer(idx)
+
+	params := map[string]interface{}{
+		"protocolVersion": "2099-01-01",
+		"capabilities":    map[string]interface{}{},
+	}
+	paramsJSON, _ := json.Marshal(params)
+
+	result, err := handleInitialize(srv, paramsJSON)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	resultMap := result.(map[string]interface{})
+	if resultMap["protocolVersion"] != defaultProtocolVersion {
+		t.Errorf("expected fallback to %s, got %v", defaultProtocolVersion, resultMap["protocolVersion"])
 	}
 }
 
@@ -42,7 +88,7 @@ func TestHandleInitialize_DuplicateInit(t *testing.T) {
 	srv.setState(stateInitialized)
 
 	params := map[string]interface{}{
-		"protocolVersion": "2025-11-25",
+		"protocolVersion": "2025-06-18",
 		"capabilities":    map[string]interface{}{},
 	}
 	paramsJSON, _ := json.Marshal(params)

--- a/internal/mcp/integration_test.go
+++ b/internal/mcp/integration_test.go
@@ -22,7 +22,7 @@ func TestIntegration_FullSession(t *testing.T) {
 	srv := NewServer(idx)
 
 	// Build input: initialize -> initialized -> tools/list -> tools/call
-	input := `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{}}}
+	input := `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{}}}
 {"jsonrpc":"2.0","method":"notifications/initialized"}
 {"jsonrpc":"2.0","id":2,"method":"tools/list"}
 {"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"tmkb_query","arguments":{"context":"background job processing","language":"python"}}}

--- a/internal/mcp/stdio_test.go
+++ b/internal/mcp/stdio_test.go
@@ -12,7 +12,7 @@ func TestServeStdio_InitializeFlow(t *testing.T) {
 	idx := knowledge.NewIndex()
 	srv := NewServer(idx)
 
-	input := `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{}}}
+	input := `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{}}}
 {"jsonrpc":"2.0","method":"notifications/initialized"}
 `
 
@@ -28,7 +28,7 @@ func TestServeStdio_InitializeFlow(t *testing.T) {
 	}
 
 	// First line should be initialize response
-	if !strings.Contains(lines[0], `"protocolVersion":"2025-11-25"`) {
+	if !strings.Contains(lines[0], `"protocolVersion":"2025-06-18"`) {
 		t.Error("expected initialize response")
 	}
 


### PR DESCRIPTION
## Summary

Fixes the `-32000` (`ConnectionClosed`) failure that prevented the tmkb MCP server from reconnecting in Claude Code. `-32000` means the server process died/closed its pipes before completing the handshake — not an error the server returns. There were **two independent root causes**:

1. **Hardcoded protocol version.** `handleInitialize` replied `protocolVersion: "2025-11-25"` to every `initialize`, ignoring the client's request. `2025-11-25` is not a published MCP spec revision, so a compliant client rejected the handshake.
2. **`TMKB_PATTERNS` was never read.** `.mcp.json` points the server at its patterns via `TMKB_PATTERNS`, but `findPatternsDir()` only scanned cwd-relative paths. MCP clients launch the server with *their* project as cwd (no `patterns/` there), so `LoadAll()` failed in `PersistentPreRunE` and the process exited before answering `initialize`. Bug 2 was masked by Bug 1: a by-hand handshake from the repo dir resolves `./patterns` and looks healthy.

## Changes

- **`internal/mcp/initialize.go`** — replace the no-op block with `negotiateProtocolVersion()`: echo the client's version when supported (`2025-06-18`, `2025-03-26`, `2024-11-05`), else fall back to `2025-06-18`. Added echo + fallback regression tests; updated tests that asserted `2025-11-25`.
- **`internal/cli/root.go`** — `findPatternsDir()` now returns `os.Getenv("TMKB_PATTERNS")` directly (cleaned) when set, so a misconfigured path fails loudly instead of silently falling back to cwd. Renamed the knowledge test's stray `TMKB_PATTERNS_DIR` override to `TMKB_PATTERNS`.
- **Docs** — `docs/mcp-integration.md` and the `examples/claude-code-integration` troubleshooting command updated to the negotiated version. Dated artifacts under `docs/plans/` and `docs/validation/` left as historical records.

## Verification

- `gofmt -l internal/`: clean · `go vet ./...`: exit 0 · `go test ./...`: all packages ok
- **E2E from a non-repo cwd (`/tmp`)**, mimicking a real client launch:
  - No `TMKB_PATTERNS` → reproduced the failure: `failed to load patterns: ... lstat patterns: no such file or directory`, exit 1, no handshake.
  - With `TMKB_PATTERNS` → loaded 12 patterns, completed handshake, returned `"protocolVersion":"2025-06-18"`, exit 0.
- Live negotiation: requested `2025-03-26` echoed back; unsupported `2099-01-01` fell back to `2025-06-18`.

> Note: the runtime binary is gitignored — a rebuild (`go build -o ./tmkb ./cmd/tmkb`) + `/mcp` reconnect is needed for the fix to take effect in a running session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)