### PR TITLE
docs(mcp): document automatic tmkb_query invocation options

### DIFF
--- a/docs/mcp-integration.md
+++ b/docs/mcp-integration.md
@@ -121,6 +121,150 @@ TMKB returns:
 }
 ```
 
+## Automatic Invocation
+
+By default, `tmkb_query` is only called when the assistant *decides* to: it
+reads your request, infers that authorization context is relevant, and invokes
+the tool. That works, but it is non-deterministic — on a quick edit the model
+may skip the query entirely.
+
+If you want TMKB consulted *reliably* (before every code edit, for compliance
+or team-wide consistency), Claude Code offers several mechanisms that invoke the
+tool without depending on the model's judgement. They differ in how
+deterministic they are and what they cost per use:
+
+| Mechanism | Determinism | Triggered by | Best for | Trade-off |
+|-----------|-------------|--------------|----------|-----------|
+| [PreToolUse hook](#pretooluse-hook) | Highest — fires on every matching tool call | The harness, automatically | Guaranteeing a query before each code edit | A query (latency + tokens) on *every* matched edit; generic context |
+| [Slash command](#slash-command) | High, but user-initiated | You typing `/tmkb` | On-demand, deliberate queries | Only runs when you remember to invoke it |
+| [Skill / subagent hook](#skill-or-subagent-frontmatter-hook) | High, scoped | The harness, while that skill/agent is active | Limiting auto-queries to security-relevant work | Only fires inside that skill/agent's context |
+| [Project instructions](#project-instructions-claudemd) | Low — guidance, not enforcement | The model, prompted | Steering deliberate queries with tailored context | The model can still skip it |
+
+These are complementary, not mutually exclusive. A common setup pairs a
+**PreToolUse hook** (a guaranteed backstop) with **CLAUDE.md guidance** (so the
+model also queries *deliberately*, with a `context` tailored to the feature —
+which a generic hook can't express).
+
+> **Backstop, not a replacement.** An automatic hook fires a generic query; it
+> can't describe the specific feature being built the way a deliberate query
+> can. Treat it as a safety net that guarantees *something* relevant is in
+> context, and still query TMKB intentionally during design.
+
+### PreToolUse hook
+
+A [hook](https://code.claude.com/docs/en/hooks) of type `mcp_tool` calls
+`tmkb_query` automatically before the assistant writes or edits a file, and
+injects the returned patterns into context. Add it to a Claude Code settings
+file (see [Where hooks live](#where-hooks-live)):
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Write|Edit|MultiEdit|NotebookEdit",
+        "hooks": [
+          {
+            "type": "mcp_tool",
+            "server": "tmkb",
+            "tool": "tmkb_query",
+            "input": {
+              "context": "About to edit ${tool_input.file_path}; surface authorization and trust-boundary threats before generating code.",
+              "language": "python",
+              "framework": "flask",
+              "verbosity": "agent"
+            },
+            "timeout": 15,
+            "statusMessage": "Consulting TMKB…"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+- `matcher` filters on tool name. A bare `|`-separated list (e.g.
+  `Write|Edit|MultiEdit`) is exact matching; include any other character and it
+  is treated as a JavaScript regular expression (e.g. `mcp__.*`).
+- `${tool_input.file_path}` is substituted with the path being edited, so the
+  query reflects the file in play.
+- `server` must match the name you registered under `mcpServers`
+  (see [Configuration](#configuration)); `tool` is `tmkb_query`. This `hooks`
+  block lives in a *settings* file, which is separate from the `mcpServers`
+  registration.
+- The tool's output is placed in the model's context next to the tool result.
+  To inject it explicitly, have the hook return JSON containing
+  `hookSpecificOutput.additionalContext`.
+- `timeout` (seconds) bounds the call — keep it short, since it runs on every
+  matched edit.
+
+> First-run note: hooks that fire before the MCP server has connected (e.g.
+> `SessionStart`) may no-op. `PreToolUse` runs once the server is up, so the
+> query resolves.
+
+### Where hooks live
+
+Hook config goes in a Claude Code **settings** file — distinct from the
+`mcpServers` registration covered under [Configuration](#configuration). The
+same `hooks` block works in any of these; they differ in scope and whether they
+are shared:
+
+| File | Scope | Committed to the repo? |
+|------|-------|------------------------|
+| `.claude/settings.json` | This project, all contributors | Yes — shared with the team |
+| `.claude/settings.local.json` | This project, just you | No — gitignored by default |
+| `~/.claude/settings.json` | All your projects | No — lives in your home directory |
+
+Pick based on who should get the behavior: commit to `.claude/settings.json` to
+apply it for everyone working in the repo, or use `.claude/settings.local.json`
+/ `~/.claude/settings.json` to opt yourself in without changing the repo. When
+the same setting appears in more than one file, the more specific scope wins
+(`settings.local.json` over `settings.json` over `~/.claude/settings.json`).
+
+### Slash command
+
+A custom slash command lets you fire a TMKB query on demand by typing `/tmkb`.
+Create `.claude/commands/tmkb.md` (project) or `~/.claude/commands/tmkb.md`
+(personal):
+
+```markdown
+---
+description: Query TMKB for authorization threats relevant to the current work
+---
+
+Call the `mcp__tmkb__tmkb_query` tool with a `context` describing what we are
+building right now, plus `language: "python"` and `framework: "flask"`. Apply
+each returned pattern's `check` and `fix` before writing code.
+```
+
+This is deterministic about *what* runs, but you have to invoke it — useful when
+you want one deliberate, well-scoped query rather than one on every edit.
+
+### Skill or subagent frontmatter hook
+
+Skills and subagents can declare their own `hooks` in YAML frontmatter. A
+`PreToolUse` hook defined there fires only while that skill or subagent is
+active, giving you the determinism of the hook approach scoped to
+security-relevant work instead of every edit in the session. Use the same
+`mcp_tool` hook block shown above, placed in the skill/subagent frontmatter
+rather than in a settings file.
+
+### Project instructions (CLAUDE.md)
+
+The lowest-friction option is to instruct the assistant to query TMKB in your
+project's `CLAUDE.md`. This is guidance, not enforcement — the model can still
+skip it — but it lets you request a query with a `context` tailored to each
+feature, which a generic hook can't. It pairs well with a PreToolUse hook
+backstop:
+
+```markdown
+Before writing or modifying code that touches auth, multi-tenancy, background
+jobs, file ownership, or trust boundaries, call `mcp__tmkb__tmkb_query` with a
+`context` describing the feature, plus `language: "python"` and
+`framework: "flask"`. Apply each returned pattern's `check` and `fix`.
+```
+
 ## Troubleshooting
 
 ### Server Won't Start
@@ -259,4 +403,6 @@ ln -s /other/patterns/* /main/patterns/
 
 - [MCP Specification](https://modelcontextprotocol.io/specification/2025-06-18)
 - [Claude Code MCP Documentation](https://docs.anthropic.com/claude/docs/model-context-protocol)
+- [Claude Code hooks](https://code.claude.com/docs/en/hooks)
+- [Claude Code settings](https://code.claude.com/docs/en/settings)
 - [TMKB GitHub](https://github.com/mark-chris/tmkb)


### PR DESCRIPTION
## Summary

Adds an **Automatic Invocation** section to `docs/mcp-integration.md` explaining how to invoke the `tmkb_query` MCP tool deterministically, rather than relying on the model to decide. Presented as an equal-weight menu of options with no pushed default:

- **PreToolUse hook** (`type: "mcp_tool"`) — fires `tmkb_query` automatically before every matching `Write`/`Edit`/etc., with a worked JSON example and field notes.
- **Slash command** (`/tmkb`) — on-demand, deliberate queries.
- **Skill / subagent frontmatter hook** — the hook approach scoped to security-relevant work.
- **Project instructions (CLAUDE.md)** — low-friction guidance, paired with a hook as a backstop.

Also adds a settings-file scope/precedence table ("Where hooks live") and two reference links (Claude Code hooks, Claude Code settings).

## Verification

All technical claims were verified against the current Claude Code docs before writing:

- `type: "mcp_tool"` hook exists; `server`/`tool`/`input`/`timeout`/`statusMessage` are valid fields on it.
- `${tool_input.file_path}` substitution works inside the hook `input` object.
- `matcher` does exact `|` alternation, regex otherwise; `hookSpecificOutput.additionalContext` injects context for `PreToolUse`.
- Settings precedence is Local > Project > User, as documented in the new table.
- Skill/subagent frontmatter `hooks` and `.claude/commands/*.md` slash commands are both real.

Docs-only change — diff touches `docs/mcp-integration.md` exclusively (+146 lines). All in-page anchor links resolve to existing headings; code fences balance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)