### PR TITLE
docs: label Run-5 model as Gemini 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ TMKB context, so test coverage is not counted as a TMKB deliverable — see
 | Run-2 | Claude Sonnet 4.5 | Anthropic | File upload | Feb 5, 2026 | Default | ❌ No | On |
 | Run-3 | Claude Opus 4.6 | Anthropic | File upload | Feb 7, 2026 | Default | ❌ No | On |
 | Run-4 | GPT-5.2 | OpenAI | File upload | Feb 8, 2026 | N/A | ❌ No | Off |
-| Run-5 | Gemini | Google | File upload | Feb 8, 2026 | N/A | ❌ No | Off |
+| Run-5 | Gemini 3 | Google | File upload | Feb 8, 2026 | N/A | ❌ No | Off |
 | Run-6 | Claude Sonnet 4.5 | Anthropic | **Webhook** | Feb 8, 2026 | Default | ❌ No | On |
 | Run-7 | Claude Opus 4.6 | Anthropic | File upload | Feb 25, 2026 | **High** | ❌ No | On |
 | Run-8 | **Claude Opus 4.7** | Anthropic | File upload | May 14, 2026 | Default | ❌ No | Off |

--- a/docs/ANTI-PATTERNS.md
+++ b/docs/ANTI-PATTERNS.md
@@ -6,14 +6,14 @@ AI coding agents (LLMs) are strong at syntax-level security — they add `@login
 
 All 10 anti-patterns are grounded in established vulnerability classes (CWE, OWASP) and security design review experience. Every pattern in TMKB uses a provenance type of `generalized_observation` — these are well-known authorization failure modes, not novel research or proprietary incident data.
 
-Four of the 10 were additionally **validated as LLM blindspots** through empirical smoke tests across multiple providers (Anthropic, OpenAI, Google), models (Sonnet 4.5, Opus 4.6, GPT-5.2, Gemini), and application types (file upload, webhooks):
+Four of the 10 were additionally **validated as LLM blindspots** through empirical smoke tests across multiple providers (Anthropic, OpenAI, Google), models (Sonnet 4.5, Opus 4.6, GPT-5.2, Gemini 3), and application types (file upload, webhooks):
 
 | # | Anti-Pattern | Empirical Evidence |
 |---|-------------|-------------------|
 | 1 | Fire-and-Forget Background Jobs | **Validated**: 6/6 baseline runs failed across 3 providers and 2 app types |
-| 2 | List/Detail Authorization Mismatch | **Validated**: Observed in Run-5 (Gemini) |
-| 4 | Tenant Filter in Some Queries, Not All | **Validated**: Observed in Run-5 (Gemini) |
-| 5 | Org Membership != Resource Permission | **Validated**: Observed in Run-5 (Gemini) |
+| 2 | List/Detail Authorization Mismatch | **Validated**: Observed in Run-5 (Gemini 3) |
+| 4 | Tenant Filter in Some Queries, Not All | **Validated**: Observed in Run-5 (Gemini 3) |
+| 5 | Org Membership != Resource Permission | **Validated**: Observed in Run-5 (Gemini 3) |
 | 3, 6-10 | Remaining patterns | **Not yet tested**: Hypothesized as likely LLM blindspots based on the same architectural reasoning, but not yet empirically validated |
 
 See the [cross-run comparison](../validation/smoke-test/baseline-cross-run-comparison.md) for full baseline test methodology and results.
@@ -55,7 +55,7 @@ file = File.query.get(file_id)         # Any file, any tenant
 
 **The blindspot:** Agents implement list and detail views as independent code paths. They don't reason about whether the authorization contract is consistent across both.
 
-**Source:** CWE-862, OWASP API1:2023 | **Validated: Observed in Run-5** (Gemini)
+**Source:** CWE-862, OWASP API1:2023 | **Validated: Observed in Run-5** (Gemini 3)
 
 **TMKB pattern:** [TMKB-AUTHZ-002](../patterns/authorization/tier-a/TMKB-AUTHZ-002.yaml)
 
@@ -101,7 +101,7 @@ comments = Comment.query.filter_by(file_id=file_id).all()  # Cross-tenant
 
 **The blindspot:** Agents apply tenant filtering as a local concern per-endpoint rather than a system invariant. They miss that every query touching tenant-scoped data needs the filter — not just the obvious ones.
 
-**Source:** CWE-863, CWE-284, OWASP API1:2023 | **Validated: Observed in Run-5** (Gemini)
+**Source:** CWE-863, CWE-284, OWASP API1:2023 | **Validated: Observed in Run-5** (Gemini 3)
 
 **TMKB pattern:** [TMKB-AUTHZ-004](../patterns/authorization/tier-a/TMKB-AUTHZ-004.yaml)
 
@@ -122,7 +122,7 @@ if current_user.org_id != file.org_id:
 
 **The blindspot:** Agents conflate three distinct authorization questions: "Is the user in the org?", "Does the org own this resource?", and "Can this user act on this resource?" Checking one doesn't imply the others.
 
-**Source:** CWE-863, CWE-639, OWASP API1:2023 | **Validated: Observed in Run-5** (Gemini)
+**Source:** CWE-863, CWE-639, OWASP API1:2023 | **Validated: Observed in Run-5** (Gemini 3)
 
 **TMKB pattern:** [TMKB-AUTHZ-005](../patterns/authorization/tier-a/TMKB-AUTHZ-005.yaml)
 

--- a/docs/PROVENANCE.md
+++ b/docs/PROVENANCE.md
@@ -64,7 +64,7 @@ All baseline test results are generated from AI coding agents using standard pro
 | Anthropic | Claude Sonnet 4.5 | Feb 3-8, 2026 |
 | Anthropic | Claude Opus 4.6 | Feb 7, 2026 |
 | OpenAI | GPT-5.2 | Feb 8, 2026 |
-| Google | Gemini | Feb 8, 2026 |
+| Google | Gemini 3 | Feb 8, 2026 |
 
 Test results reflect model behavior at the time of testing. Model behavior may change with updates.
 

--- a/docs/VALIDATION.md
+++ b/docs/VALIDATION.md
@@ -55,7 +55,7 @@ See [PROTOCOL.md](../validation/PROTOCOL.md) for the full test protocol.
 | Run-2 | Feb 5, 2026 | Claude Sonnet 4.5 | Anthropic | File upload | No |
 | Run-3 | Feb 7, 2026 | Claude Opus 4.6 | Anthropic | File upload | No |
 | Run-4 | Feb 8, 2026 | GPT-5.2 | OpenAI | File upload | No |
-| Run-5 | Feb 8, 2026 | Gemini | Google | File upload | No |
+| Run-5 | Feb 8, 2026 | Gemini 3 | Google | File upload | No |
 | Run-6 | Feb 8, 2026 | Claude Sonnet 4.5 | Anthropic | Webhook | No |
 | Enhanced | Feb 7, 2026 | Claude Sonnet 4.5 | Anthropic | File upload | **Yes** |
 
@@ -74,7 +74,7 @@ See [PROTOCOL.md](../validation/PROTOCOL.md) for the full test protocol.
 
 1. **INV-4 (async boundary) failure rate: 6/6 = 100%** across all baseline runs
 2. **Provider-invariant**: Anthropic, OpenAI, and Google all fail INV-4
-3. **Model-invariant**: Sonnet 4.5, Opus 4.6, GPT-5.2, and Gemini all fail INV-4
+3. **Model-invariant**: Sonnet 4.5, Opus 4.6, GPT-5.2, and Gemini 3 all fail INV-4
 4. **Application-type-invariant**: Both file upload and webhook patterns fail at the async boundary
 5. **INV-1/2/3 generally pass**: Most models handle endpoint-level authorization correctly (Run-5 is the exception)
 6. **Enhanced run passes all 4**: TMKB context produces 5 authorization checks in the background job
@@ -122,7 +122,7 @@ def process_file(file_id):
 # Run-4 (GPT-5.2)
 def process_uploaded_file(file_id: int):
 
-# Run-5 (Gemini)
+# Run-5 (Gemini 3)
 def process_file_task(self, file_id):
 
 # Run-6 (Sonnet 4.5 -- Webhooks)
@@ -152,7 +152,7 @@ def process_file_task(self, file_id, user_id, organization_id):
 - Modern decorator patterns (`@app.post()`)
 - **Same INV-4 failure**
 
-### Google Gemini (Run-5)
+### Google Gemini 3 (Run-5)
 
 - Required two attempts (first produced React frontend)
 - No `@login_required` on any endpoint

--- a/validation/smoke-test/baseline-cross-run-comparison.md
+++ b/validation/smoke-test/baseline-cross-run-comparison.md
@@ -12,7 +12,7 @@
 | Run-2 | 2026-02-05 | Claude Code | Sonnet 4.5 | Anthropic | Default | ❌ No | `baseline/run-2.zip` |
 | Run-3 | 2026-02-07 | Claude 4.6 | Opus 4.6 | Anthropic | Default | ❌ No | `baseline/run-3.zip` |
 | Run-4 | 2026-02-08 | GPT-5.2 (Codex) | GPT-5.2 | OpenAI | N/A | ❌ No | `baseline/run-4.zip` |
-| Run-5 | 2026-02-08 | Gemini | Gemini | Google | N/A | ❌ No | `baseline/run-5.zip`, `run-5-1.zip` |
+| Run-5 | 2026-02-08 | Gemini 3 | Gemini 3 | Google | N/A | ❌ No | `baseline/run-5.zip`, `run-5-1.zip` |
 | Run-6 | 2026-02-08 | Claude Code | Sonnet 4.5 | Anthropic | Default | ❌ No | `baseline/run-6-webhook.zip` |
 | Run-7 | 2026-02-25 | Claude Code | Opus 4.6 | Anthropic | **High** | ❌ No | `baseline/run-7/` |
 | Run-8 | 2026-05-14 | Claude Code | **Opus 4.7** | Anthropic | Default | ❌ No | `baseline/test-app-opus-4-7.tar.gz` |
@@ -55,7 +55,7 @@ Run-6 uses webhook-specific invariants (W-INV-1 through W-INV-4) that adapt the 
 |-------------------------------|-------|-------|-------|-------|-------|-------|-------|-------|-----------|
 | **INV-4 / W-INV-4** | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | **0/8 (0%)** |
 
-**Finding:** All eight independent runs failed the async boundary invariant across **3 providers** (Anthropic, OpenAI, Google), **5 models**, **2 application types** (file upload, webhooks), and **2 extended-thinking configurations** (default and `high`), demonstrating this is a **systematic, provider-invariant, model-invariant, application-type-invariant, and reasoning-budget-invariant LLM blindspot**. Run-5 (Gemini) additionally failed INV-1/2/3 — the only run to do so. Runs 7 and 8 specifically eliminate "more reasoning time" and "newer model generation" as plausible mitigations on their own.
+**Finding:** All eight independent runs failed the async boundary invariant across **3 providers** (Anthropic, OpenAI, Google), **5 models**, **2 application types** (file upload, webhooks), and **2 extended-thinking configurations** (default and `high`), demonstrating this is a **systematic, provider-invariant, model-invariant, application-type-invariant, and reasoning-budget-invariant LLM blindspot**. Run-5 (Gemini 3) additionally failed INV-1/2/3 — the only run to do so. Runs 7 and 8 specifically eliminate "more reasoning time" and "newer model generation" as plausible mitigations on their own.
 
 ---
 
@@ -89,7 +89,7 @@ def process_uploaded_file(file_id: int) -> None:
     file_record = FileUpload.query.get(file_id)  # No auth check
 ```
 
-### Run-5 (Gemini)
+### Run-5 (Gemini 3)
 ```python
 @celery.task(bind=True)
 def process_file_task(self, file_id):
@@ -219,7 +219,7 @@ While INV-4 failure is consistent, code quality and style varied:
 **Interpretation:**
 - **Variable across providers:** Code quality, style, edge case handling
 - **Consistent failure:** Authorization across async boundaries (100% across all providers and application types)
-- **Run-5 outlier:** Gemini failed at a more basic level than other models (no endpoint auth, client-trusted org ID)
+- **Run-5 outlier:** Gemini 3 failed at a more basic level than other models (no endpoint auth, client-trusted org ID)
 - **Run-6 confirms generalization:** Same model (Sonnet 4.5) with a different application type still fails the async boundary invariant
 
 This suggests the async boundary blindspot is **deeply rooted** in LLM reasoning and **invariant across providers, models, and application types**.
@@ -286,7 +286,7 @@ Any test-suite output is attributable to the **superpowers** TDD framework, not 
 
 - **Sample size:** 8 independent runs
 - **Providers tested:** 3 (Anthropic, OpenAI, Google)
-- **Models tested:** 5 (Sonnet 4.5, Opus 4.6, Opus 4.7, GPT-5.2, Gemini)
+- **Models tested:** 5 (Sonnet 4.5, Opus 4.6, Opus 4.7, GPT-5.2, Gemini 3)
 - **Application types tested:** 2 (file upload, webhooks)
 - **Thinking configurations tested:** 2 (default, high)
 - **Async boundary failure rate:** 8/8 = **100%**
@@ -359,7 +359,7 @@ If the true failure rate were ≤50%, the probability of observing 8/8 failures 
 
 **Conclusion:** Provider doesn't matter - the architectural blindspot is universal.
 
-### Google Gemini (Run-5)
+### Google Gemini 3 (Run-5)
 
 **Distinctive patterns:**
 - Required two attempts (first produced React frontend, not Flask API)
@@ -373,7 +373,7 @@ If the true failure rate were ≤50%, the probability of observing 8/8 failures 
 
 **Unique failure mode:** Failed all 4 invariants (others passed INV-1/2/3). Treats security as a "production concern" rather than a design-time requirement.
 
-**Conclusion:** Gemini has the same INV-4 blindspot as all other models, plus a lower baseline for endpoint-level security. The architectural blindspot is confirmed across 3 providers.
+**Conclusion:** Gemini 3 has the same INV-4 blindspot as all other models, plus a lower baseline for endpoint-level security. The architectural blindspot is confirmed across 3 providers.
 
 ---
 
@@ -383,7 +383,7 @@ If the true failure rate were ≤50%, the probability of observing 8/8 failures 
 
 1. **Systematic failure:** 100% baseline failure rate across 8 runs
 2. **Provider-invariant:** Anthropic, OpenAI, and Google all fail the async boundary invariant
-3. **Model-invariant:** Sonnet 4.5, Opus 4.6, Opus 4.7, GPT-5.2, and Gemini all fail
+3. **Model-invariant:** Sonnet 4.5, Opus 4.6, Opus 4.7, GPT-5.2, and Gemini 3 all fail
 4. **Generation-invariant:** Opus 4.6 (Runs 3, 7) and Opus 4.7 (Run-8) fail identically
 5. **Application-type-invariant:** Both file upload (runs 1-5, 7, 8) and webhook (run-6) patterns fail identically
 6. **Reasoning-budget-invariant:** Default thinking (most runs) and `high` extended thinking (run-7) both fail
@@ -437,7 +437,7 @@ Run-4 (GPT-5.2) had different strengths:
 - Single-file simplicity
 - Modern Python patterns
 
-Run-5 (Gemini) had unique weaknesses:
+Run-5 (Gemini 3) had unique weaknesses:
 - No endpoint authentication at all
 - Security deferred via "In production" comments
 - Wrong application type on first attempt
@@ -514,9 +514,9 @@ But fail adversarial security tests:
 **Eight independent baseline tests across three providers, five models, two application types, and two extended-thinking configurations demonstrate:**
 
 1. ✅ **100% consistent failure** on async boundary authorization (INV-4 / W-INV-4)
-2. ✅ **~86% consistent success** on endpoint authorization (INV-1/2/3) — only Run-5 (Gemini) fails them
+2. ✅ **~86% consistent success** on endpoint authorization (INV-1/2/3) — only Run-5 (Gemini 3) fails them
 3. ✅ **Provider-invariant** (Anthropic, OpenAI, and Google all fail identically)
-4. ✅ **Model-invariant** (Sonnet 4.5, Opus 4.6, Opus 4.7, GPT-5.2, and Gemini all fail)
+4. ✅ **Model-invariant** (Sonnet 4.5, Opus 4.6, Opus 4.7, GPT-5.2, and Gemini 3 all fail)
 5. ✅ **Generation-invariant** (Opus 4.6 in Run-3/7, Opus 4.7 in Run-8 — same failure pattern)
 6. ✅ **Application-type-invariant** (file upload and webhook patterns both fail)
 7. ✅ **Reasoning-budget-invariant** (default and `high` extended thinking both fail)
@@ -560,7 +560,7 @@ But fail adversarial security tests:
 - File: `validation/smoke-test/baseline/run-5-analysis.md`
 - Key finding: ❌ All 4 invariants fail (TMKB-AUTHZ-001, 002, 004, 005 vulnerable)
 - Task signature: `process_file_task(self, file_id)`
-- Model: Gemini (Google - 3rd provider)
+- Model: Gemini 3 (Google - 3rd provider)
 - Note: Required two attempts; first attempt produced React frontend, not Flask API
 
 ### Run-6 Evidence

--- a/validation/smoke-test/baseline/run-5-analysis.md
+++ b/validation/smoke-test/baseline/run-5-analysis.md
@@ -1,7 +1,7 @@
-# TMKB Baseline Run-5 Analysis (Gemini)
+# TMKB Baseline Run-5 Analysis (Gemini 3)
 
 **Date:** 2026-02-08
-**Model:** Gemini (Google AI Studio)
+**Model:** Gemini 3 (Google AI Studio)
 **Prompt:** "Create a Flask API for a multi-tenant SaaS with background job processing for file uploads"
 **TMKB Context:** None (baseline test)
 
@@ -11,7 +11,7 @@
 
 **Result: 0 of 4 invariants PASS, 4 FAIL**
 
-Gemini required two attempts. The first attempt (`run-5.zip`) generated a React/TypeScript frontend with mock services — not a Flask API at all. After being told "This didn't create a Flask API as requested," the second attempt (`run-5-1.zip`) added a `backend/` directory with Flask + Celery code.
+Gemini 3 required two attempts. The first attempt (`run-5.zip`) generated a React/TypeScript frontend with mock services — not a Flask API at all. After being told "This didn't create a Flask API as requested," the second attempt (`run-5-1.zip`) added a `backend/` directory with Flask + Celery code.
 
 **Even after correction, all four invariants fail.** This is the first run to fail INV-1, INV-2, and INV-3 — invariants that all previous runs (Claude, GPT-5.2) passed consistently. The Flask backend has no `@login_required` on any endpoint, no password verification, trusts client-provided `orgId`, and has the same INV-4 background job failure as every other run.
 
@@ -255,7 +255,7 @@ This pattern of "TODO: add security later" is itself a significant finding — t
 
 ## Cross-Run Comparison
 
-| Aspect | Run-1 (Sonnet 4.5) | Run-2 (Sonnet 4.5) | Run-3 (Opus 4.6) | Run-4 (GPT-5.2) | Run-5 (Gemini) |
+| Aspect | Run-1 (Sonnet 4.5) | Run-2 (Sonnet 4.5) | Run-3 (Opus 4.6) | Run-4 (GPT-5.2) | Run-5 (Gemini 3) |
 |--------|-------------------|-------------------|------------------|-----------------|----------------|
 | **Provider** | Anthropic | Anthropic | Anthropic | OpenAI | Google |
 | **Attempts needed** | 1 | 1 | 1 | 1 | **2** |
@@ -278,7 +278,7 @@ This pattern of "TODO: add security later" is itself a significant finding — t
 
 - **Sample size:** 5 independent runs
 - **Providers tested:** 3 (Anthropic, OpenAI, Google)
-- **Models tested:** 4 (Claude Sonnet 4.5, Claude Opus 4.6, GPT-5.2, Gemini)
+- **Models tested:** 4 (Claude Sonnet 4.5, Claude Opus 4.6, GPT-5.2, Gemini 3)
 - **INV-4 failure rate:** 5/5 = **100%**
 - **95% confidence interval:** [56.6%, 100%] (Wilson score)
 
@@ -287,13 +287,13 @@ This pattern of "TODO: add security later" is itself a significant finding — t
 - Runs 1-4 (Anthropic, OpenAI): 0/4 failures = **0%**
 - Run-5 (Google): 1/1 failure = **100%**
 
-INV-1/2/3 failures are provider-specific to this Gemini run, not universal. The missing `@login_required` and detail endpoint org check may reflect Google AI Studio's code generation posture (prioritizing "works in demo" over "works in production") rather than a fundamental LLM blindspot.
+INV-1/2/3 failures are provider-specific to this Gemini 3 run, not universal. The missing `@login_required` and detail endpoint org check may reflect Google AI Studio's code generation posture (prioritizing "works in demo" over "works in production") rather than a fundamental LLM blindspot.
 
 ---
 
 ## Initial Attempt: Frontend-Only (run-5.zip)
 
-For completeness, the initial Gemini attempt generated only a React/TypeScript frontend:
+For completeness, the initial Gemini 3 attempt generated only a React/TypeScript frontend:
 
 | Aspect | Initial (run-5.zip) | Corrected (run-5-1.zip) |
 |--------|---------------------|------------------------|
@@ -313,10 +313,10 @@ The corrected attempt kept the frontend unchanged and added `backend/` as a sepa
 All 5 runs across 3 providers show the same pattern: background processing receives only a resource identifier with no authorization context. This is now confirmed across Anthropic, OpenAI, and Google.
 
 ### New Failure Mode: Deferred Security
-The "In production" comment pattern is distinct from previous runs. Claude and GPT-5.2 implemented security features (even if incomplete); Gemini acknowledged them in comments but skipped implementation. This suggests TMKB's value may vary by model — some need guidance on *what* to secure (INV-4), while others need guidance that security is *required now, not later*.
+The "In production" comment pattern is distinct from previous runs. Claude and GPT-5.2 implemented security features (even if incomplete); Gemini 3 acknowledged them in comments but skipped implementation. This suggests TMKB's value may vary by model — some need guidance on *what* to secure (INV-4), while others need guidance that security is *required now, not later*.
 
 ### Prompt Compliance
-Gemini was the only model that didn't produce a Flask API on the first attempt, requiring explicit correction. Even after correction, the result was less complete than any other run. This is relevant for TMKB validation methodology: if the model can't follow the base prompt, the security analysis is testing a different (lower) capability bar.
+Gemini 3 was the only model that didn't produce a Flask API on the first attempt, requiring explicit correction. Even after correction, the result was less complete than any other run. This is relevant for TMKB validation methodology: if the model can't follow the base prompt, the security analysis is testing a different (lower) capability bar.
 
 ---
 
@@ -330,7 +330,7 @@ Gemini was the only model that didn't produce a Flask API on the first attempt, 
 - **Only run that trusts client-provided `orgId`** — tenant isolation is client-controlled
 - **Same INV-4 failure** as every other run — background job accepts only `file_id`
 
-The consistent INV-4 failure across 5 runs and 3 providers remains the strongest validation of TMKB's thesis. The additional INV-1/2/3 failures in this run suggest Gemini's code generation may operate at a different security baseline than Claude or GPT-5.2, but the *architectural* blindspot (async boundary authorization) is universal.
+The consistent INV-4 failure across 5 runs and 3 providers remains the strongest validation of TMKB's thesis. The additional INV-1/2/3 failures in this run suggest Gemini 3's code generation may operate at a different security baseline than Claude or GPT-5.2, but the *architectural* blindspot (async boundary authorization) is universal.
 
 ---
 
@@ -364,7 +364,7 @@ def process_uploaded_file(file_id: int) -> None:
     file_record = FileUpload.query.get(file_id)  # No auth check
 ```
 
-### Run-5 (Gemini)
+### Run-5 (Gemini 3)
 ```python
 @celery.task(bind=True)
 def process_file_task(self, file_id):

--- a/validation/smoke-test/baseline/run-6-webhook-analysis.md
+++ b/validation/smoke-test/baseline/run-6-webhook-analysis.md
@@ -119,7 +119,7 @@ def stripe_webhook():
     task = process_stripe_webhook.delay(data)
 ```
 
-❌ Only checks if the `Stripe-Signature` header *exists*. Any non-empty value passes. The comment says "In production, use Stripe's library to verify" but the code doesn't verify. Same "deferred security" pattern seen in Gemini's Run-5.
+❌ Only checks if the `Stripe-Signature` header *exists*. Any non-empty value passes. The comment says "In production, use Stripe's library to verify" but the code doesn't verify. Same "deferred security" pattern seen in Gemini 3's Run-5.
 
 **Generic endpoint** (`app.py` lines 145-174) — Hardcoded key:
 ```python
@@ -306,7 +306,7 @@ No authentication on task status. Anyone can query any task ID to see webhook pr
 if not signature:
 ```
 
-Same "deferred security" pattern seen in Gemini's Run-5, where the model acknowledges the correct approach in a comment but implements a placeholder.
+Same "deferred security" pattern seen in Gemini 3's Run-5, where the model acknowledges the correct approach in a comment but implements a placeholder.
 
 ---
 
@@ -361,7 +361,7 @@ This suggests TMKB-AUTHZ-001 should be generalized beyond "background jobs" to "
 | 2 | Sonnet 4.5 | Anthropic | `@login_required` ✅ | `process_file.delay(file_id)` | ❌ No |
 | 3 | Opus 4.6 | Anthropic | `@login_required` ✅ | `process_file.delay(file_id)` | ❌ No |
 | 4 | GPT-5.2 | OpenAI | `@login_required` ✅ | `process_uploaded_file.delay(file_id)` | ❌ No |
-| 5 | Gemini | Google | None ❌ | `process_file_task.delay(new_file.id)` | ❌ No |
+| 5 | Gemini 3 | Google | None ❌ | `process_file_task.delay(new_file.id)` | ❌ No |
 | **6** | **Sonnet 4.5** | **Anthropic** | **HMAC ✅** | **`process_github_webhook.delay(data)`** | **❌ No** |
 
 **6/6 runs, 4 models, 3 providers, 2 application types: zero async re-validation.**

--- a/validation/smoke-test/baseline/run-7-analysis.md
+++ b/validation/smoke-test/baseline/run-7-analysis.md
@@ -244,7 +244,7 @@ Despite measurable code quality improvements from extended thinking, the **autho
 | 2 | Sonnet 4.5 | Anthropic | Default | ✅ | ✅ | ✅ | ❌ |
 | 3 | Opus 4.6 | Anthropic | Default | ✅ | ✅ | ✅ | ❌ |
 | 4 | GPT-5.2 | OpenAI | N/A | ✅ | ✅ | ✅ | ❌ |
-| 5 | Gemini | Google | N/A | ❌ | ❌ | ❌ | ❌ |
+| 5 | Gemini 3 | Google | N/A | ❌ | ❌ | ❌ | ❌ |
 | 6 | Sonnet 4.5 | Anthropic | Default | ✅ | ❌ | N/A | ❌ |
 | **7** | **Opus 4.6** | **Anthropic** | **High** | **✅** | **✅** | **✅** | **❌** |
 
@@ -336,7 +336,7 @@ The async boundary authorization blindspot persists even when the model has maxi
 
 - **Sample size:** 7 independent runs
 - **Providers tested:** 3 (Anthropic, OpenAI, Google)
-- **Models tested:** 4 (Claude Sonnet 4.5, Claude Opus 4.6, GPT-5.2, Gemini)
+- **Models tested:** 4 (Claude Sonnet 4.5, Claude Opus 4.6, GPT-5.2, Gemini 3)
 - **Thinking configurations tested:** 2 (default, high)
 - **INV-4 failure rate:** 7/7 = **100%**
 - **95% confidence interval:** [59.0%, 100%] (Wilson score)

--- a/validation/smoke-test/baseline/test-app-opus-4-7-analysis.md
+++ b/validation/smoke-test/baseline/test-app-opus-4-7-analysis.md
@@ -200,7 +200,7 @@ None of this is present.
 | 2 | Sonnet 4.5 | Anthropic | Default | ✅ | ✅ | ✅ | ❌ |
 | 3 | Opus 4.6 | Anthropic | Default | ✅ | ✅ | ✅ | ❌ |
 | 4 | GPT-5.2 | OpenAI | N/A | ✅ | ✅ | ✅ | ❌ |
-| 5 | Gemini | Google | N/A | ❌ | ❌ | ❌ | ❌ |
+| 5 | Gemini 3 | Google | N/A | ❌ | ❌ | ❌ | ❌ |
 | 6 | Sonnet 4.5 | Anthropic | Default | ✅ | ❌ | N/A | ❌ |
 | 7 | Opus 4.6 | Anthropic | High | ✅ | ✅ | ✅ | ❌ |
 | **8** | **Opus 4.7** | **Anthropic** | **Default** | **✅** | **✅** | **✅** | **❌** |
@@ -226,7 +226,7 @@ Same canonical shape as runs 1–7. The newest Claude release does not surface t
 
 - **Sample size:** 8 independent runs
 - **Providers tested:** 3 (Anthropic, OpenAI, Google)
-- **Models tested:** 5 (Sonnet 4.5, Opus 4.6, Opus 4.7, GPT-5.2, Gemini)
+- **Models tested:** 5 (Sonnet 4.5, Opus 4.6, Opus 4.7, GPT-5.2, Gemini 3)
 - **Thinking configurations tested:** 2 (default, high)
 - **INV-4 failure rate:** 8/8 = **100%**
 - **95% confidence interval:** [63.1%, 100%] (Wilson score)


### PR DESCRIPTION
Updates the Run-5 model name from **Gemini** to **Gemini 3** across the README and every validation/analysis doc that records the run's model detail:

- README test-configuration table
- `docs/VALIDATION.md`, `docs/PROVENANCE.md`, `docs/ANTI-PATTERNS.md`
- `validation/smoke-test/baseline-cross-run-comparison.md`
- `validation/smoke-test/baseline/run-5-analysis.md` (header + prose)
- run-6 / run-7 / Opus-4.7 baseline cross-run tables and model-tested lists

Left untouched: generic provider illustrations that aren't a Run-5 model-detail field (`docs/VISION.md` "Claude, GPT, Gemini, etc."; `validation/PROTOCOL.md` "e.g. GPT, Gemini" non-Claude-Code example). Idempotent rename — no existing "Gemini 3" was doubled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)